### PR TITLE
Change getUrl() method to use HTTP Request Defaults config settings

### DIFF
--- a/src/main/java/com/atlantbh/jmeter/plugins/rest/RestSampler.java
+++ b/src/main/java/com/atlantbh/jmeter/plugins/rest/RestSampler.java
@@ -95,11 +95,20 @@ public class RestSampler extends HTTPSampler2 {
     }
 
     public URL getUrl() throws MalformedURLException{
-        String validHost = toValidUrl(getHostBaseUrl());
         URL u = null;
-        if (validHost != null && getResource() != null) {
-            String fullUrl = validHost + ":" + getPortNumber() + "/" + getResource();
-            u = toURL(fullUrl);
+        try {
+            String validHost = toValidUrl(getHostBaseUrl());
+            if (validHost != null && getResource() != null) {
+                String fullUrl = validHost + ":" + getPortNumber() + "/" + getResource();
+                u = toURL(fullUrl);
+            } 
+        } catch (MalformedURLException e)  {
+
+            if(isProtocolDefaultPort()) {
+                u = new URL(getProtocol(), getDomain(), getPath() + "/" + getResource());
+            } else {
+                u = new URL(getProtocol(), getDomain(), getPort(), getPath() + "/" + getResource());            
+            }
         }
        
         return u;


### PR DESCRIPTION
Those changes will apply HTTP Request Defaults jmeter config element settings to Rest Sampler when running. Original idea was taken from parent HTTPSamplerBase class.

Using HTTP Request Defaults config element helps to define server, http protocol, port and path variables in one place for same project. So the only thing is need to be specified in Rest Sample is a REST resource.
