### PR TITLE
JSON Format Post Processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
 			<artifactId>ApacheJMeter_java</artifactId>
 			<version>${jmeter.version}</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.9.5</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonformatter/JSONFormatter.java
+++ b/src/main/java/com/atlantbh/jmeter/plugins/jsonutils/jsonformatter/JSONFormatter.java
@@ -10,11 +10,14 @@
 package com.atlantbh.jmeter.plugins.jsonutils.jsonformatter;
 
 import net.sf.json.JSONArray;
+import net.sf.json.JSONException;
 import net.sf.json.JSONObject;
 
 import org.apache.jmeter.processor.PostProcessor;
 import org.apache.jmeter.testelement.AbstractTestElement;
 import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jorphan.logging.LoggingManager;
+import org.apache.log.Logger;
 
 /**
  * This is main class for JSON formatter which contains formatJSON method that takes sample result and do pretty
@@ -24,7 +27,7 @@ import org.apache.jmeter.threads.JMeterContext;
  */
 
 public class JSONFormatter extends AbstractTestElement implements PostProcessor {
-
+	private static final Logger LOG = LoggingManager.getLoggerForClass();
 	private static final long serialVersionUID = 1L;
 
 	public JSONFormatter() {
@@ -32,7 +35,6 @@ public class JSONFormatter extends AbstractTestElement implements PostProcessor 
 	}
 
 	public String formatJSON(String json) {
-
 		if (json.startsWith("[") && json.endsWith("]")) {
 			return JSONArray.fromObject(json).toString(4);
 		} else {
@@ -44,6 +46,11 @@ public class JSONFormatter extends AbstractTestElement implements PostProcessor 
 	public void process() {
 		JMeterContext context = getThreadContext();
 		String responseData = context.getPreviousResult().getResponseDataAsString();
-		context.getPreviousResult().setResponseData((this.formatJSON(responseData)).getBytes());
+
+		try {
+			context.getPreviousResult().setResponseData((this.formatJSON(responseData)).getBytes());
+		} catch(JSONException e) {
+			LOG.warn("Exception thrown while formatting JSON response", e);
+		}
 	}
 }

--- a/src/test/java/com/atlantbh/jmeter/plugins/jsonutils/jsonformatter/JSONFormatterTest.java
+++ b/src/test/java/com/atlantbh/jmeter/plugins/jsonutils/jsonformatter/JSONFormatterTest.java
@@ -1,0 +1,88 @@
+package com.atlantbh.jmeter.plugins.jsonutils.jsonformatter;
+
+import org.apache.jmeter.threads.JMeterContext;
+import org.apache.jmeter.samplers.SampleResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+
+@RunWith(MockitoJUnitRunner.class)
+public class JSONFormatterTest {
+	private JSONFormatter formatter = new JSONFormatter();
+
+	@Mock
+	private JMeterContext context;
+
+	@Mock
+	private SampleResult sampleResult;
+
+	@Before
+	public void setUp() throws Exception {
+		formatter.setThreadContext(context);
+	}
+
+	@Test
+	public void shouldProcessJSONObjectString() throws Exception {
+		when(context.getPreviousResult()).thenReturn(sampleResult);
+		String json = "{\"foo\":\"bar\"}";
+
+		when(sampleResult.getResponseDataAsString()).thenReturn(json);
+
+		// the method under test
+		formatter.process();
+
+		ArgumentCaptor<byte[]> result = ArgumentCaptor.forClass(byte[].class);
+
+		verify(sampleResult, times(1)).setResponseData(result.capture());
+
+		String formattedJson = new String(result.getValue());
+		formattedJson = formattedJson.replaceAll("\\s", "");
+
+		// formatted json stripped of all whitespace should equal unformatted json
+		assertEquals(json, formattedJson);
+	}
+
+	@Test
+	public void shouldProcessJSONArrayString() throws Exception {
+		when(context.getPreviousResult()).thenReturn(sampleResult);
+		String json = "[\"foo\",\"bar\"]";
+
+		when(sampleResult.getResponseDataAsString()).thenReturn(json);
+
+		// the method under test
+		formatter.process();
+
+		ArgumentCaptor<byte[]> result = ArgumentCaptor.forClass(byte[].class);
+
+		verify(sampleResult, times(1)).setResponseData(result.capture());
+
+		String formattedJson = new String(result.getValue());
+		formattedJson = formattedJson.replaceAll("\\s", "");
+
+		// formatted json stripped of all whitespace should equal unformatted json
+		assertEquals(json, formattedJson);
+	}
+
+	@Test
+	public void shouldLetUnparseableJsonFallThrough() throws Exception {
+		when(context.getPreviousResult()).thenReturn(sampleResult);
+		String json = "<html><body><h1>Something bad happened</h1></body></html>";
+
+		when(sampleResult.getResponseDataAsString()).thenReturn(json);
+
+		// the method under test
+		formatter.process();
+
+		// should never have attempted to set the body
+		verify(sampleResult, times(0)).setResponseData(any(byte[].class));
+	}
+}


### PR DESCRIPTION
I'm using the JSON Format Post Processor to make the output of our REST service a little easier to read, but currently when something happens on the server to make it not return valid JSON - exceptions, firewall blocking, etc, the net.sf.json package emits a runtime exception that causes the whole sampler to fail.  Not to be treated as an error (e.g. with a red icon in a result tree listener) but to not appear at all.

This is confusing our testers somewhat so I've updated the class to just log the exception and leave the output untouched and thrown a unit test in too.

I hope you'll consider merging this.
