### PR TITLE
XMLFormatter: Fixing FWK005 parse may not be called while parsing

### DIFF
--- a/src/main/java/com/atlantbh/jmeter/plugins/xmlformatter/XMLFormatPostProcessor.java
+++ b/src/main/java/com/atlantbh/jmeter/plugins/xmlformatter/XMLFormatPostProcessor.java
@@ -46,6 +46,9 @@ public class XMLFormatPostProcessor extends AbstractTestElement implements
 			threadContext.getPreviousResult().setResponseData(serialize2(responseString).getBytes("UTF-8"));
 		} catch (Exception e) {
 			log.info("Error while formating response xml - " + e.getMessage());
+			if (e.getMessage() == null) {
+				log.info("Message is null, showing throwable: ", e);
+			}
 		}
 	}
 

--- a/src/main/java/com/atlantbh/jmeter/plugins/xmlformatter/XmlUtil.java
+++ b/src/main/java/com/atlantbh/jmeter/plugins/xmlformatter/XmlUtil.java
@@ -24,22 +24,25 @@ import org.xml.sax.InputSource;
  */
 public class XmlUtil {
 
-private static Transformer transformer;
-private static DocumentBuilder builder;
+private final static Transformer transformer;
+private final static DocumentBuilder builder;
 	
 	static {
+		Transformer tmpTransformer = null;
+		DocumentBuilder tmpBuilder = null;
 		try{
-			transformer = TransformerFactory.newInstance().newTransformer();
-			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
-			builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+			tmpTransformer = TransformerFactory.newInstance().newTransformer();
+			tmpTransformer.setOutputProperty(OutputKeys.INDENT, "yes");
+			tmpTransformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+			tmpBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
 		}
 		catch (Exception e)
 		{
 			System.out.println(e.getMessage());
-			transformer = null;
-			builder = null;
 		}
+		transformer = tmpTransformer;
+		builder = tmpBuilder;
+
 	}
 	
 	/**
@@ -53,8 +56,9 @@ private static DocumentBuilder builder;
 		if (builder == null) {
 			throw new Exception("DocumentBuilder is null.");
 		}
-		return builder.parse(new InputSource(new ByteArrayInputStream(string.getBytes("UTF-8"))));
-	
+		synchronized (builder) {
+			return builder.parse(new InputSource(new ByteArrayInputStream(string.getBytes("UTF-8"))));
+		}
 	}
 	
 	/**
@@ -71,7 +75,9 @@ private static DocumentBuilder builder;
 		Source xmlSource = new DOMSource(document);
 		StringWriter stringWriter = new StringWriter();
         Result result = new StreamResult(stringWriter);
-		transformer.transform(xmlSource, result);
+        synchronized (transformer) {
+			transformer.transform(xmlSource, result);
+		}
 		return stringWriter.toString();
 	}
 }


### PR DESCRIPTION
When testing with multiple threads, we have got an empty response sometimes. It was caused by missing synchronization while parsing XMLs.